### PR TITLE
Improved outdated

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -27,7 +27,7 @@ runs:
       shell: bash
       run: |
         yarn global add check-outdated --preferred-cache-folder ${{ inputs.yarn-cache }}
-        echo "::add-path::$(yarn global bin)"
+        echo "$(yarn global bin)" >> $GITHUB_PATH
 
     - name: Install dependencies
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -51,14 +51,14 @@ runs:
         set +e
         cd ${{ inputs.working-dir }}
         $( ! $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/post-update )
-        echo "::set-output name=outdated::$(cat ${{ runner.temp }}/post-update)"
+        echo "::set-output name=outdated::$( cat ${{ runner.temp }}/post-update )"
 
     - name: Make diff
       shell: bash
       id: get-diff
       # strip ansi colors and fix line breaks
       run: |
-        diff=$(comm ${{ runner.temp }}/pre-update ${{ runner.temp }}/post-update) -23)
+        diff=$(comm ${{ runner.temp }}/pre-update ${{ runner.temp }}/post-update -23)
         diff=$(echo "$diff" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
         diff="${diff//'%'/'%25'}"
         diff="${diff//$'\r'/'%0D'}"

--- a/action.yaml
+++ b/action.yaml
@@ -40,7 +40,7 @@ runs:
         set +e
         cd ${{ inputs.working-dir }}
         outdated=$( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
-        outdated=echo "$outdated" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g"
+        outdated=$(echo "$outdated" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
         outdated="${outdated//$'\n'/'\n'}"
         echo "::set-output name=outdated::$outdated"
 
@@ -55,7 +55,7 @@ runs:
         set +e
         cd ${{ inputs.working-dir }}
         outdated=$( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
-        outdated=echo "$outdated" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g"
+        outdated=$(echo "$outdated" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
         outdated="${outdated//$'\n'/'\n'}"
         echo "::set-output name=outdated::$outdated"
 

--- a/action.yaml
+++ b/action.yaml
@@ -50,15 +50,15 @@ runs:
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        outdated=$( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes )
-        echo "::set-output name=outdated::$outdated"
+        $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/post-update
+        echo "::set-output name=outdated::$(cat ${{ runner.temp }}/post-update)"
 
     - name: Make diff
       shell: bash
       id: get-diff
       # strip ansi colors and fix line breaks
       run: |
-        diff=$(comm ${{ runner.temp }}/pre-update <(echo "${{ steps.get-post-update-outdated.outputs.unformatted-outdated }}") -23)
+        diff=$(comm ${{ runner.temp }}/pre-update ${{ runner.temp }}/post-update) -23)
         diff=$(echo "$diff" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
         diff="${diff//'%'/'%25'}"
         diff="${diff//$'\r'/'%0D'}"

--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,7 @@ runs:
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes
+        $( ! $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/post-update )
 
     - name: Upgrade dependencies
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -50,7 +50,7 @@ runs:
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        $( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/post-update )
+        $( ! $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/post-update )
         echo "::set-output name=outdated::$(cat ${{ runner.temp }}/post-update)"
 
     - name: Make diff

--- a/action.yaml
+++ b/action.yaml
@@ -62,5 +62,6 @@ runs:
         post=$(cat ${{ runner.temp }}/post-update | sed '1,5d' | head -n -6 | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
         diff=$(comm <(echo $pre) <(echo $post) -23)
         diff="${diff//'%'/'%25'}"
+        diff="${diff//$'\n'/'%0A'}"
         diff="${diff//$'\r'/'%0D'}"
         echo "::set-output name=diff::$diff"

--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,7 @@ runs:
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        $( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/post-update )
+        $( ! $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/post-update )
 
     - name: Upgrade dependencies
       shell: bash
@@ -50,7 +50,7 @@ runs:
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        $( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/post-update )
+        $( ! $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/post-update )
         echo "::set-output name=outdated::$(cat ${{ runner.temp }}/post-update)"
 
     - name: Make diff
@@ -60,7 +60,7 @@ runs:
       run: |
         pre=$(cat ${{ runner.temp }}/pre-update | sed '1,5d' | head -n -6 | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
         post=$(cat ${{ runner.temp }}/post-update | sed '1,5d' | head -n -6 | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
-        diff=$(comm <($pre) <($post) -23)
+        diff=$(comm <(echo $pre) <(echo $post) -23)
         diff="${diff//'%'/'%25'}"
         diff="${diff//$'\r'/'%0D'}"
         echo "::set-output name=diff::$diff"

--- a/action.yaml
+++ b/action.yaml
@@ -42,7 +42,6 @@ runs:
         cd ${{ inputs.working-dir }}
         outdated=$( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
         outdated=$(echo "$outdated" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
-        outdated="${outdated//$'\n'/'\n'}"
         echo "::set-output name=outdated::$outdated"
 
     - name: Upgrade dependencies
@@ -57,7 +56,6 @@ runs:
         cd ${{ inputs.working-dir }}
         outdated=$( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
         outdated=$(echo "$outdated" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
-        outdated="${outdated//$'\n'/'\n'}"
         echo "::set-output name=outdated::$outdated"
 
     - name: Make diff

--- a/action.yaml
+++ b/action.yaml
@@ -60,7 +60,7 @@ runs:
       run: |
         pre=$(cat ${{ runner.temp }}/pre-update | sed '1,5d' | head -n -6 | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
         post=$(cat ${{ runner.temp }}/post-update | sed '1,5d' | head -n -6 | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
-        diff=$(comm <(echo $pre) <(echo $post) -23)
+        diff=$(comm <(echo "$pre") <(echo "$post") -23)
         diff="${diff//'%'/'%25'}"
         diff="${diff//$'\n'/'%0A'}"
         diff="${diff//$'\r'/'%0D'}"

--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,8 @@ runs:
         set +e
         cd ${{ inputs.working-dir }}
         outdated=$( check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
-        outdated="${outdated//$'\n'/'\n'}"
+        echo $outdated
+#        outdated="${outdated//$'\n'/'\n'}"
         echo "::set-output name=outdated::$outdated"
 
     - name: Upgrade dependencies
@@ -52,7 +53,8 @@ runs:
         set +e
         cd ${{ inputs.working-dir }}
         outdated=$( check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
-        outdated="${outdated//$'\n'/'\n'}"
+        echo $outdated
+#        outdated="${outdated//$'\n'/'\n'}"
         echo "::set-output name=outdated::$outdated"
 
     - name: Make diff
@@ -60,6 +62,7 @@ runs:
       id: get-diff
       run: |
         diff=$(comm <(echo "${{ steps.get-pre-update-outdated.outputs.outdated }}") <(echo "${{ steps.get-post-update-outdated.outputs.unformatted-outdated }}") -23)
+        echo $diff
         diff="${diff//'%'/'%25'}"
         diff="${diff//$'\n'/'%0A'}"
         diff="${diff//$'\r'/'%0D'}"

--- a/action.yaml
+++ b/action.yaml
@@ -40,6 +40,7 @@ runs:
         set +e
         cd ${{ inputs.working-dir }}
         outdated=$( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
+        outdated=echo "$outdated" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g"
         outdated="${outdated//$'\n'/'\n'}"
         echo "::set-output name=outdated::$outdated"
 
@@ -54,6 +55,7 @@ runs:
         set +e
         cd ${{ inputs.working-dir }}
         outdated=$( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
+        outdated=echo "$outdated" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g"
         outdated="${outdated//$'\n'/'\n'}"
         echo "::set-output name=outdated::$outdated"
 

--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,7 @@ runs:
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        $( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/pre-update )
+        $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes
 
     - name: Upgrade dependencies
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -42,6 +42,7 @@ runs:
         cd ${{ inputs.working-dir }}
         outdated=$( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
         outdated=$(echo "$outdated" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
+        outdated="${outdated//$'\n'/'\n'}"
         echo "::set-output name=outdated::$outdated"
 
     - name: Upgrade dependencies
@@ -56,6 +57,7 @@ runs:
         cd ${{ inputs.working-dir }}
         outdated=$( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
         outdated=$(echo "$outdated" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
+        outdated="${outdated//$'\n'/'\n'}"
         echo "::set-output name=outdated::$outdated"
 
     - name: Make diff
@@ -64,6 +66,5 @@ runs:
       run: |
         diff=$(comm <(echo "${{ steps.get-pre-update-outdated.outputs.outdated }}") <(echo "${{ steps.get-post-update-outdated.outputs.unformatted-outdated }}") -23)
         diff="${diff//'%'/'%25'}"
-        diff="${diff//$'\n'/'%0A'}"
         diff="${diff//$'\r'/'%0D'}"
         echo "::set-output name=diff::$diff"

--- a/action.yaml
+++ b/action.yaml
@@ -58,7 +58,7 @@ runs:
       id: get-diff
       # strip ansi colors and fix line breaks
       run: |
-        diff=$(comm ${{ runner.temp }}/pre-update ${{ runner.temp }}/post-update -23)
+        diff=$(comm <(sort ${{ runner.temp }}/pre-update) <(sort ${{ runner.temp }}/post-update) -23)
         diff=$(echo "$diff" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
         diff="${diff//'%'/'%25'}"
         diff="${diff//$'\r'/'%0D'}"

--- a/action.yaml
+++ b/action.yaml
@@ -23,6 +23,10 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Install outdated tool
+      shell: bash
+      run: yarn global add check-outdated --preferred-cache-folder ${{ inputs.yarn-cache }}
+
     - name: Install dependencies
       shell: bash
       run: yarn install --no-progress --preferred-cache-folder ${{ inputs.yarn-cache }} --cwd ${{ inputs.working-dir }}
@@ -32,7 +36,8 @@ runs:
       id: get-pre-update-outdated
       run: |
         set +e
-        outdated=$( ! yarn outdated --preferred-cache-folder ${{ inputs.yarn-cache }} --cwd ${{ inputs.working-dir }} | sed '1,6d; $d')
+        cd ${{ inputs.working-dir }}
+        outdated=$( check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
         outdated="${outdated//$'\n'/'\n'}"
         echo "::set-output name=outdated::$outdated"
 
@@ -45,7 +50,8 @@ runs:
       id: get-post-update-outdated
       run: |
         set +e
-        outdated=$( ! yarn outdated --preferred-cache-folder ${{ inputs.yarn-cache }} --cwd ${{ inputs.working-dir }} | sed '1,6d; $d')
+        cd ${{ inputs.working-dir }}
+        outdated=$( check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
         outdated="${outdated//$'\n'/'\n'}"
         echo "::set-output name=outdated::$outdated"
 

--- a/action.yaml
+++ b/action.yaml
@@ -39,7 +39,6 @@ runs:
         cd ${{ inputs.working-dir }}
         outdated=$( check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
         echo $outdated
-#        outdated="${outdated//$'\n'/'\n'}"
         echo "::set-output name=outdated::$outdated"
 
     - name: Upgrade dependencies
@@ -54,9 +53,9 @@ runs:
         cd ${{ inputs.working-dir }}
         outdated=$( check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
         echo $outdated
-#        outdated="${outdated//$'\n'/'\n'}"
         echo "::set-output name=outdated::$outdated"
 
+  #        outdated="${outdated//$'\n'/'\n'}"
     - name: Make diff
       shell: bash
       id: get-diff

--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,7 @@ runs:
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        $( ! $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 > ${{ runner.temp }}/pre-update )
+        $( ! $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/pre-update )
 
     - name: Upgrade dependencies
       shell: bash
@@ -51,14 +51,14 @@ runs:
         set +e
         cd ${{ inputs.working-dir }}
         $( ! $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/post-update )
-        echo "::set-output name=outdated::$( cat ${{ runner.temp }}/post-update | sed '1,5d' | head -n -6 )"
+        echo "::set-output name=outdated::$( cat ${{ runner.temp }}/post-update )"
 
     - name: Make diff
       shell: bash
       id: get-diff
       # strip ansi colors and fix line breaks
       run: |
-        diff=$(comm ${{ runner.temp }}/pre-update ${{ runner.temp }}/post-update -23)
+        diff=$(grep -Fxv -f ${{ runner.temp }}/pre-update ${{ runner.temp }}/post-update -23)
         diff=$(echo "$diff" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
         diff="${diff//'%'/'%25'}"
         diff="${diff//$'\r'/'%0D'}"

--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,7 @@ runs:
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/pre-update
+        $( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/pre-update )
 
     - name: Upgrade dependencies
       shell: bash
@@ -50,7 +50,7 @@ runs:
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/post-update
+        $( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/post-update )
         echo "::set-output name=outdated::$(cat ${{ runner.temp }}/post-update)"
 
     - name: Make diff

--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,7 @@ runs:
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        $( ! $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/pre-update )
+        $( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/post-update )
 
     - name: Upgrade dependencies
       shell: bash
@@ -50,16 +50,17 @@ runs:
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        $( ! $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/post-update )
-        echo "::set-output name=outdated::$( cat ${{ runner.temp }}/post-update )"
+        $( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/post-update )
+        echo "::set-output name=outdated::$(cat ${{ runner.temp }}/post-update)"
 
     - name: Make diff
       shell: bash
       id: get-diff
       # strip ansi colors and fix line breaks
       run: |
-        diff=$(grep -Fxv -f ${{ runner.temp }}/pre-update ${{ runner.temp }}/post-update -23)
-        diff=$(echo "$diff" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
+        pre=$(cat ${{ runner.temp }}/pre-update | sed '1,5d' | head -n -6 | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
+        post=$(cat ${{ runner.temp }}/post-update | sed '1,5d' | head -n -6 | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
+        diff=$(comm <($pre) <($post) -23)
         diff="${diff//'%'/'%25'}"
         diff="${diff//$'\r'/'%0D'}"
         echo "::set-output name=diff::$diff"

--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,7 @@ runs:
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        $( ! $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/pre-update )
+        $( ! $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 > ${{ runner.temp }}/pre-update )
 
     - name: Upgrade dependencies
       shell: bash
@@ -51,14 +51,14 @@ runs:
         set +e
         cd ${{ inputs.working-dir }}
         $( ! $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/post-update )
-        echo "::set-output name=outdated::$( cat ${{ runner.temp }}/post-update )"
+        echo "::set-output name=outdated::$( cat ${{ runner.temp }}/post-update | sed '1,5d' | head -n -6 )"
 
     - name: Make diff
       shell: bash
       id: get-diff
       # strip ansi colors and fix line breaks
       run: |
-        diff=$(comm <(sort ${{ runner.temp }}/pre-update) <(sort ${{ runner.temp }}/post-update) -23)
+        diff=$(comm ${{ runner.temp }}/pre-update ${{ runner.temp }}/post-update -23)
         diff=$(echo "$diff" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
         diff="${diff//'%'/'%25'}"
         diff="${diff//$'\r'/'%0D'}"

--- a/action.yaml
+++ b/action.yaml
@@ -35,13 +35,10 @@ runs:
 
     - name: Check pre update outdated
       shell: bash
-      id: get-pre-update-outdated
-      # strip ansi colors and fix line breaks
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        outdated=$( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes )
-        echo "::set-output name=outdated::$outdated"
+        $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/pre-update
 
     - name: Upgrade dependencies
       shell: bash
@@ -54,14 +51,14 @@ runs:
         set +e
         cd ${{ inputs.working-dir }}
         outdated=$( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes )
-        echo $outdated
         echo "::set-output name=outdated::$outdated"
 
     - name: Make diff
       shell: bash
       id: get-diff
+      # strip ansi colors and fix line breaks
       run: |
-        diff=$(comm <(echo "${{ steps.get-pre-update-outdated.outputs.outdated }}") <(echo "${{ steps.get-post-update-outdated.outputs.unformatted-outdated }}") -23)
+        diff=$(comm ${{ runner.temp }}/pre-update <(echo "${{ steps.get-post-update-outdated.outputs.unformatted-outdated }}") -23)
         diff=$(echo "$diff" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
         diff="${diff//'%'/'%25'}"
         diff="${diff//$'\r'/'%0D'}"

--- a/action.yaml
+++ b/action.yaml
@@ -36,6 +36,7 @@ runs:
     - name: Check pre update outdated
       shell: bash
       id: get-pre-update-outdated
+      # strip ansi colors and fix line breaks
       run: |
         set +e
         cd ${{ inputs.working-dir }}

--- a/action.yaml
+++ b/action.yaml
@@ -40,7 +40,7 @@ runs:
         set +e
         cd ${{ inputs.working-dir }}
         outdated=$( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
-        echo $outdated
+        outdated="${outdated//$'\n'/'\n'}"
         echo "::set-output name=outdated::$outdated"
 
     - name: Upgrade dependencies
@@ -54,10 +54,9 @@ runs:
         set +e
         cd ${{ inputs.working-dir }}
         outdated=$( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
-        echo $outdated
+        outdated="${outdated//$'\n'/'\n'}"
         echo "::set-output name=outdated::$outdated"
 
-  #        outdated="${outdated//$'\n'/'\n'}"
     - name: Make diff
       shell: bash
       id: get-diff

--- a/action.yaml
+++ b/action.yaml
@@ -25,7 +25,9 @@ runs:
   steps:
     - name: Install outdated tool
       shell: bash
-      run: yarn global add check-outdated --preferred-cache-folder ${{ inputs.yarn-cache }}
+      run: |
+        yarn global add check-outdated --preferred-cache-folder ${{ inputs.yarn-cache }}
+        echo "::add-path::$(yarn global bin)"
 
     - name: Install dependencies
       shell: bash
@@ -37,7 +39,7 @@ runs:
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        outdated=$( check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
+        outdated=$( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
         echo $outdated
         echo "::set-output name=outdated::$outdated"
 
@@ -51,7 +53,7 @@ runs:
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        outdated=$( check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
+        outdated=$( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
         echo $outdated
         echo "::set-output name=outdated::$outdated"
 

--- a/action.yaml
+++ b/action.yaml
@@ -40,9 +40,7 @@ runs:
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        outdated=$( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
-        outdated=$(echo "$outdated" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
-        outdated="${outdated//$'\n'/'\n'}"
+        outdated=$( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes )
         echo "::set-output name=outdated::$outdated"
 
     - name: Upgrade dependencies
@@ -55,9 +53,8 @@ runs:
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        outdated=$( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes | sed '1,5d' | head -n -6 )
-        outdated=$(echo "$outdated" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
-        outdated="${outdated//$'\n'/'\n'}"
+        outdated=$( $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes )
+        echo $outdated
         echo "::set-output name=outdated::$outdated"
 
     - name: Make diff
@@ -65,6 +62,7 @@ runs:
       id: get-diff
       run: |
         diff=$(comm <(echo "${{ steps.get-pre-update-outdated.outputs.outdated }}") <(echo "${{ steps.get-post-update-outdated.outputs.unformatted-outdated }}") -23)
+        diff=$(echo "$diff" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed -r "s/\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" )
         diff="${diff//'%'/'%25'}"
         diff="${diff//$'\r'/'%0D'}"
         echo "::set-output name=diff::$diff"

--- a/action.yaml
+++ b/action.yaml
@@ -62,7 +62,6 @@ runs:
       id: get-diff
       run: |
         diff=$(comm <(echo "${{ steps.get-pre-update-outdated.outputs.outdated }}") <(echo "${{ steps.get-post-update-outdated.outputs.unformatted-outdated }}") -23)
-        echo $diff
         diff="${diff//'%'/'%25'}"
         diff="${diff//$'\n'/'%0A'}"
         diff="${diff//$'\r'/'%0D'}"

--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,7 @@ runs:
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        $( ! $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/post-update )
+        $( ! $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/pre-update )
 
     - name: Upgrade dependencies
       shell: bash


### PR DESCRIPTION
yarn outdated only shows outdated packages in package.json. This command shows more levels deep. It still doesn't show everything it seems... but I couldn't find anything better.

So it does show @sentry/serverless but not @sentry/node for example... might be something in how the sentry package works I guess.