### PR TITLE
Npm global install

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -20,8 +20,7 @@ runs:
     - name: Install outdated tool
       shell: bash
       run: |
-        yarn global add check-outdated
-        echo "$(yarn global bin)" >> $GITHUB_PATH
+        npm install -g check-outdated
 
     - run: yarn versions
       shell: bash
@@ -34,7 +33,7 @@ runs:
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        $( ! $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/pre-update )
+        $( ! check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/pre-update )
 
     - name: Upgrade dependencies
       shell: bash
@@ -46,7 +45,7 @@ runs:
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        $( ! $(yarn global bin)/check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/post-update )
+        $( ! check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/post-update )
         echo "::set-output name=outdated::$(cat ${{ runner.temp }}/post-update)"
 
     - name: Make diff

--- a/action.yaml
+++ b/action.yaml
@@ -15,6 +15,8 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - run: yarn versions
+      shell: bash
     - name: Install outdated tool
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -15,15 +15,11 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - run: yarn versions
-      shell: bash
     - name: Install outdated tool
       shell: bash
       run: |
         npm install -g check-outdated
 
-    - run: yarn versions
-      shell: bash
     - name: Install dependencies
       shell: bash
       run: yarn install --no-progress --cwd ${{ inputs.working-dir }}

--- a/action.yaml
+++ b/action.yaml
@@ -23,6 +23,8 @@ runs:
         yarn global add check-outdated
         echo "$(yarn global bin)" >> $GITHUB_PATH
 
+    - run: yarn versions
+      shell: bash
     - name: Install dependencies
       shell: bash
       run: yarn install --no-progress --cwd ${{ inputs.working-dir }}


### PR DESCRIPTION
somehow the `yarn global add` seemed to interfere with the node version being used causing github actions to fail:
https://github.com/Pararius/casco-admin/actions/runs/1086682574
https://github.com/Pararius/casco-listing/runs/3168676932?check_suite_focus=true