### PR TITLE
fix outdated check

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -29,7 +29,7 @@ runs:
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        $( ! check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/pre-update )
+        $( check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/pre-update ) || true
 
     - name: Upgrade dependencies
       shell: bash
@@ -41,7 +41,7 @@ runs:
       run: |
         set +e
         cd ${{ inputs.working-dir }}
-        $( ! check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/post-update )
+        $( check-outdated --depth 1000 --ignore-dev-dependencies --columns name,current,latest,changes > ${{ runner.temp }}/post-update ) || true
         echo "::set-output name=outdated::$(cat ${{ runner.temp }}/post-update)"
 
     - name: Make diff


### PR DESCRIPTION
Not really sure why this breaks now. Perhaps we get a different version because we are on node 16 now instead of 10. But the exit code is different now. I guess we can safely ignore this. I kinda wonder if we really use this check-outdated output anyway as it usually is not complete. So another approach would be to remove it.